### PR TITLE
Allow stream_context options

### DIFF
--- a/GoogleStrategy.php
+++ b/GoogleStrategy.php
@@ -131,7 +131,8 @@ class GoogleStrategy extends OpauthStrategy{
 	 * @return array Parsed JSON results
 	 */
 	private function userinfo($access_token){
-		$userinfo = $this->serverGet('https://www.googleapis.com/oauth2/v1/userinfo', array('access_token' => $access_token), null, $headers);
+        	$options = isset($this->strategy['context_options']) ? $this->strategy['context_options'] : null;
+		$userinfo = $this->serverGet('https://www.googleapis.com/oauth2/v1/userinfo', array('access_token' => $access_token), $options, $headers);
 		if (!empty($userinfo)){
 			return $this->recursiveGetObjectVars(json_decode($userinfo));
 		}


### PR DESCRIPTION
Stream context options (like proxy, ssl settings a.s.o.) need to be allowed to work behind proxy.
